### PR TITLE
Add Admin Dashboard with stats for members, events, campaigns, and monthly attendees

### DIFF
--- a/prisma/migrations/20241008134855_updated_campaign/migration.sql
+++ b/prisma/migrations/20241008134855_updated_campaign/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - Added the required column `blurb` to the `Campaign` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `content` to the `CampaignContent` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Campaign" ADD COLUMN     "blurb" TEXT NOT NULL,
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "CampaignContent" ADD COLUMN     "content" TEXT NOT NULL,
+ADD COLUMN     "status" "Status" NOT NULL DEFAULT 'Draft';

--- a/prisma/migrations/20241008135536_updated/migration.sql
+++ b/prisma/migrations/20241008135536_updated/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Campaign" ALTER COLUMN "updatedAt" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,7 +101,10 @@ model Registration {
 model Campaign {
   id              String            @id @default(cuid())
   campaignTitle   String
+  blurb           String
   frequency       CampaignFrequency @default(Monthly)
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
   campaignContent CampaignContent[]
   Subscribers     Subscribers[]
 }
@@ -109,6 +112,8 @@ model Campaign {
 model CampaignContent {
   id          Int      @id @default(autoincrement()) @db.Oid
   campaignId  String
+  content     String
+  status      Status   @default(Draft)
   scheduledOn DateTime
 
   campaign Campaign @relation(fields: [campaignId], references: [id])

--- a/src/controllers/admin/office.ts
+++ b/src/controllers/admin/office.ts
@@ -1,7 +1,9 @@
 import { prismaClient } from "@/main";
 import { createToken } from "@/middleware/authentication/token";
 import { AdminLoginRequest } from "@/types/login";
+import { group } from "console";
 import { Request, Response } from "express";
+import { date } from "zod";
 
 export const AdminLoginHandler = async (req: Request, res: Response) => {
   const validBody = AdminLoginRequest.safeParse(req.body);
@@ -37,6 +39,158 @@ export const AdminLoginHandler = async (req: Request, res: Response) => {
     });
   } catch (e) {
     // TODO: Setup logger for all internal server errors
+    return res.status(500).json({
+      message: "Internal Server Error! Please try again later."
+    });
+  }
+}
+
+export const AdminDashboardHandler = async (req: Request, res: Response) => {
+  try{
+    const activeMembers_thisyear = await prismaClient.user.count({
+      where: {
+        createdAt : {gte : new Date(new Date().getFullYear(),0,1)}
+      }
+    });
+
+    const activeMembers_alltime = await prismaClient.user.count()
+
+    const activeMembers_lastyear = await prismaClient.user.count({
+      where: {
+        createdAt : {gte : new Date(new Date().getFullYear()-1,0,1), lt : new Date(new Date().getFullYear(),0,1)}
+      }
+    });
+
+    const EventsCompleted_thisyear = await prismaClient.event.count({
+      where:{
+        endTime : {gte : new Date(new Date().getFullYear(),0,1), lte : new Date()}
+      }
+    });
+
+    const EventsCompleted_alltime = await prismaClient.event.count({
+      where:{
+        endTime : {lte : new Date()}
+      }
+    });
+
+    const EventsCompleted_lastyear = await prismaClient.event.count({
+      where:{
+        endTime : {gte : new Date(new Date().getFullYear()-1,0,1), lte : new Date(new Date().getFullYear(),0,1)}
+      }
+    });
+
+    const registrations_thisyear = await prismaClient.registration.count({
+      where:{
+        createdAt : {gte : new Date(new Date().getFullYear(),0,1)}
+      }
+    });
+
+    const events_thisyear = await prismaClient.event.count({
+      where:{
+        startTime : {gte : new Date(new Date().getFullYear(),0,1)}
+      }
+    });
+
+    let avgregistrations_thisyear = registrations_thisyear/events_thisyear;
+
+    if(isNaN(avgregistrations_thisyear)){
+      avgregistrations_thisyear = 0;
+    }
+
+    const registrations_alltime = await prismaClient.registration.count();
+
+    const events_alltime = await prismaClient.event.count();
+
+    let avgregistrations_alltime = registrations_alltime/events_alltime;
+
+    if(isNaN(avgregistrations_alltime)){
+      avgregistrations_alltime = 0;
+    }
+
+    const registrations_lastyear = await prismaClient.registration.count({
+      where:{
+        createdAt : {gte : new Date(new Date().getFullYear()-1,0,1), lt : new Date(new Date().getFullYear(),0,1)}
+      }
+    });
+
+    const events_lastyear = await prismaClient.event.count({
+      where:{
+        startTime : {gte : new Date(new Date().getFullYear()-1,0,1), lt : new Date(new Date().getFullYear(),0,1)}
+      }
+    });
+
+    let avgregistrations_lastyear = registrations_lastyear/events_lastyear;
+
+    if(isNaN(avgregistrations_lastyear)){
+      avgregistrations_lastyear = 0;
+    }
+
+    const campaign_thisyear = await prismaClient.campaign.count({
+      where:{
+        createdAt : {gte : new Date(new Date().getFullYear(),0,1)}
+      }
+    })
+
+    const campaign_alltime = await prismaClient.campaign.count();
+
+    const campaign_lastyear = await prismaClient.campaign.count({
+      where:{
+        createdAt : {gte : new Date(new Date().getFullYear()-1,0,1), lt : new Date(new Date().getFullYear(),0,1)}
+      }
+    })
+
+    const data = {
+      ActiveMembers: {
+        ThisYear: activeMembers_thisyear,
+        AllTime: activeMembers_alltime,
+        LastYear: activeMembers_lastyear
+      },
+      EventsCompleted: {
+        ThisYear: EventsCompleted_thisyear,
+        AllTime: EventsCompleted_alltime,
+        LastYear: EventsCompleted_lastyear
+      },
+      AvgAttendeesPerEvent:{
+        ThisYear: avgregistrations_thisyear.toFixed(3),
+        AllTime: avgregistrations_alltime.toFixed(3),
+        LastYear: avgregistrations_lastyear.toFixed(3)
+      },
+      campaigns:{
+        ThisYear: campaign_thisyear,
+        AllTime: campaign_alltime,
+        LastYear: campaign_lastyear
+      }
+    }
+
+    const registration = await prismaClient.event.findMany({
+      select: {
+        startTime: true,
+        Registration:true
+      }
+    })
+
+    const month = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+
+    const attandees_month = new Array(12).fill(0);
+
+    registration.forEach((event)=>{
+      if (event.startTime && event.startTime.getFullYear()==new Date().getFullYear() && event.Registration){
+        attandees_month[new Date(event.startTime).getMonth()] += event.Registration.length;
+      }
+    });
+
+    const charData = attandees_month.map((attendees: number, index: number) => ({
+      month: month[index],attendees: attendees
+    }));
+
+    return res.status(200).json({
+      data,
+      charData
+    });
+  }
+
+
+  catch (e) {
     return res.status(500).json({
       message: "Internal Server Error! Please try again later."
     });

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -7,12 +7,13 @@ import {
   CreateEventHandler,
   EditEventHandler,
 } from "@/controllers/admin/event";
+import { AdminDashboardHandler } from "@/controllers/admin/office";
 
 const router = Router();
 
 // Admin-Controls
 router.post("/office/login", AdminLoginHandler);
-// router.get("/office/dashboard", validateToken, AdminDashboardHandler);
+router.get("/office/dashboard", validateToken, AdminDashboardHandler);
 // router.get("/office", validateToken, GetAllAdminHandler);
 // router.post("/office/new", validateToken, CreateAdminHandler);
 // router.post("/office/edit/{adminId}", validateToken, EditAdminHandler);


### PR DESCRIPTION
## Overview:
This PR introduces an admin dashboard endpoint that provides statistical insights for active members, events, campaigns, and attendees. The data includes breakdowns for the current year, all-time, and the previous year, with average event registrations and attendees per month.

## Features:
1. **Active Members:**
   - Fetches count of active members for this year, last year, and all-time.

2. **Events Completed:**
   - Retrieves the number of events completed this year, last year, and all-time.

3. **Average Registrations per Event:**
   - Calculates average event registrations for the current year, last year, and all-time.

4. **Campaign Statistics:**
   - Provides campaign count for this year, last year, and all-time.

5. **Monthly Attendees Data:**
   - Generates a dataset of attendee counts per month for the current year, to be used for chart visualization.